### PR TITLE
Fix types for story feature

### DIFF
--- a/src/components/story/StoryModal.tsx
+++ b/src/components/story/StoryModal.tsx
@@ -7,9 +7,17 @@ interface Props {
   users: User[];
   initialUserIndex: number;
   onClose: () => void;
+  onNext: () => void;
+  onPrevious: () => void;
 }
 
-export const StoryModal: React.FC<Props> = ({ users, initialUserIndex, onClose }) => {
+export const StoryModal: React.FC<Props> = ({
+  users,
+  initialUserIndex,
+  onClose,
+  onNext,
+  onPrevious
+}) => {
   const {
     currentUserIndex,
     handleNext,

--- a/src/components/story/StoryViewer.tsx
+++ b/src/components/story/StoryViewer.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { User } from '../../types';
+import { User, Story } from '../../types';
 import { XMarkIcon } from '@heroicons/react/24/solid';
 
 interface Props {
@@ -32,7 +32,7 @@ export const StoryViewer: React.FC<Props> = ({ user, onClose }) => {
       <div className="w-full h-full max-w-lg mx-auto relative">
         {/* Progress bars */}
         <div className="absolute top-0 left-0 right-0 flex gap-1 p-2 z-10">
-          {stories.map((_, index) => (
+          {stories.map((story: Story, index: number) => (
             <div key={index} className="flex-1 h-0.5 bg-gray-600">
               <div
                 className="h-full bg-white transition-all duration-100"

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type React from 'react';
+
 export interface User {
   id: string;
   name: string;
@@ -12,6 +14,8 @@ export interface User {
     Instagram: string;
     LinkedIn: string;
   };
+  /** Stories posted by the user */
+  stories?: Story[];
   // Social media verification fields
   instagramUrl?: string;
   instagramVerified?: boolean;
@@ -49,6 +53,13 @@ export interface Media {
   id: string;
   mediaUrl: string;
   caption?: string;
+  timestamp: string;
+}
+
+export interface Story {
+  id: string;
+  mediaUrl: string;
+  caption: string;
   timestamp: string;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
-  "exclude": ["lib", "app"]
+  "exclude": ["lib", "app", "src/pages", "src/view-models"]
 }


### PR DESCRIPTION
## Summary
- export `Story` interface and reference it from `User`
- add navigation callbacks to `StoryModal`
- type `StoryViewer` progress bar map callback
- exclude NativeScript files from the web tsconfig

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684aef0bb0e0833389ae044ee776dd9c