### PR TITLE
Add PWA support and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:18 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:18-slim AS prod
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+RUN npm install -g serve
+EXPOSE 4173
+CMD ["serve", "-s", "dist", "-l", "4173"]

--- a/README.md
+++ b/README.md
@@ -145,6 +145,17 @@ npm run build
 npm run preview
 ```
 
+### Docker
+You can build a production image using the provided `Dockerfile`:
+```bash
+docker build -t sonar-social .
+docker run -p 4173:4173 sonar-social
+```
+
+### Progressive Web App
+The project is configured as a PWA using `vite-plugin-pwa`. When built for
+production, the app can be installed on mobile devices and works offline.
+
 ## 🔮 Future Enhancements
 
 - **Real-time Messaging** - WebSocket integration

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.0.3",
+    "vite-plugin-pwa": "^0.15.1",
     "typescript": "^5.0.2",
     "vite": "^4.4.5"
   }

--- a/public/icon-192.png
+++ b/public/icon-192.png
@@ -1,0 +1,1 @@
+[Binary content of the Sonar logo]

--- a/public/icon-512.png
+++ b/public/icon-512.png
@@ -1,0 +1,1 @@
+[Binary content of the Sonar logo]

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "Sonar - Connect Locally",
+  "short_name": "Sonar",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,7 +92,7 @@ export default function App() {
         </main>
 
         {/* Bottom Navigation */}
-        <nav className="bg-gray-900 border-t border-gray-800 safe-area-inset-bottom">
+        <nav className="bg-gray-900 border-t border-gray-800 safe-area-inset-bottom fixed bottom-0 left-0 right-0 z-10">
           <div className="flex justify-around items-center py-2 px-4 h-16">
             <button
               onClick={() => setActiveTab('radar')}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,36 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      injectRegister: 'auto',
+      includeAssets: ['favicon.ico', 'icons/icon-192.png', 'icons/icon-512.png'],
+      manifest: {
+        name: 'Sonar - Connect Locally',
+        short_name: 'Sonar',
+        start_url: '/',
+        display: 'standalone',
+        background_color: '#000000',
+        theme_color: '#000000',
+        icons: [
+          {
+            src: 'icon-192.png',
+            sizes: '192x192',
+            type: 'image/png'
+          },
+          {
+            src: 'icon-512.png',
+            sizes: '512x512',
+            type: 'image/png'
+          }
+        ]
+      }
+    })
+  ],
   server: {
     host: '0.0.0.0',
     port: 5173


### PR DESCRIPTION
## Summary
- keep bottom navigation fixed so it's visible on mobile
- register a web manifest for PWA support
- configure vite-plugin-pwa
- include PWA icons
- add Dockerfile for deployment
- document Docker and PWA usage

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afbd334f48333ad06a94d54bfefc0